### PR TITLE
Add support for managing multiple subscriptions

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,6 @@
-data "azurerm_subscription" "primary" {}
+data "azurerm_subscription" "current_subscription" {
+  subscription_id = var.azure_subscription_id
+}
 
 data "azurerm_resource_group" "current_resource_group" {
   name = var.azure_resource_group
@@ -7,4 +9,9 @@ data "azurerm_resource_group" "current_resource_group" {
 data "azurerm_kubernetes_cluster" "current_aks_cluster" {
   name                = var.aks_cluster_name
   resource_group_name = data.azurerm_resource_group.current_resource_group.name
+}
+
+data "azurerm_subscription" "managed_subscriptions" {
+  for_each        = toset(var.managed_subscription_ids)
+  subscription_id = each.key
 }

--- a/resource.tf
+++ b/resource.tf
@@ -5,9 +5,30 @@ resource "azurerm_user_assigned_identity" "otterize_operator_managed_identity" {
 }
 
 resource "azurerm_role_assignment" "assign_otterize_operator_resource_group_owner" {
-  scope                = data.azurerm_subscription.primary.id
+  scope                = data.azurerm_resource_group.current_resource_group.id
   role_definition_name = "Owner"
   principal_id         = azurerm_user_assigned_identity.otterize_operator_managed_identity.principal_id
+
+  depends_on = [
+    azurerm_user_assigned_identity.otterize_operator_managed_identity,
+  ]
+}
+
+resource "azurerm_role_assignment" "assign_otterize_operator_subscription_user_access_administrator" {
+  scope                = data.azurerm_subscription.current_subscription.id
+  role_definition_name = "User Access Administrator"
+  principal_id         = azurerm_user_assigned_identity.otterize_operator_managed_identity.principal_id
+
+  depends_on = [
+    azurerm_user_assigned_identity.otterize_operator_managed_identity,
+  ]
+}
+
+resource "azurerm_role_assignment" "assign_otterize_operator_managed_subscriptions_user_access_administrator" {
+  for_each            = data.azurerm_subscription.managed_subscriptions
+  scope               = each.value.id
+  role_definition_name = "User Access Administrator"
+  principal_id        = azurerm_user_assigned_identity.otterize_operator_managed_identity.principal_id
 
   depends_on = [
     azurerm_user_assigned_identity.otterize_operator_managed_identity,

--- a/variable.tf
+++ b/variable.tf
@@ -23,3 +23,9 @@ variable "otterize_deploy_namespace" {
   type        = string
   default     = "otterize-system"
 }
+
+variable "managed_subscription_ids" {
+  description = "To allow the operator to manage multiple subscriptions, provide a list of subscription IDs"
+  type    = list(string)
+  default = []
+}

--- a/variable.tf
+++ b/variable.tf
@@ -25,7 +25,7 @@ variable "otterize_deploy_namespace" {
 }
 
 variable "managed_subscription_ids" {
-  description = "To allow the operator to manage multiple subscriptions, provide a list of subscription IDs"
+  description = "To allow the operator to manage access to resources outside the provided AKS cluster's subscription, provide a list of additional subscription IDs"
   type    = list(string)
   default = []
 }


### PR DESCRIPTION
### Description

- Changed "Owner" to "User Access Administrator" role for least-privilege control.
- Added support for managing multiple subscriptions by providing a list of ids in the "managed_subscription_ids" variable. `
managed_subscription_ids = [
  "00000000-0000-0000-0000-000000000000", ...
]
`

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
